### PR TITLE
Email provider needs an absolute path

### DIFF
--- a/src/_includes/contact_form.njk
+++ b/src/_includes/contact_form.njk
@@ -36,10 +36,12 @@
                     <input type="text" name="_honey" id="honey-pot">
                 </div>
             </div>
-        <input type="hidden" name="_next" value="{{ '/' | url}}">
+        {# email provider doesn't know what to do with the relative path #}
+        {# <input type="hidden" name="_next" value="{{ '/' | url }}"> #}
+        <input type="hidden" name="_next" value="https://actq.hubco.dev">
         <input type="hidden" name="_captcha" value="true">
         
-        {# <div class="g-recaptcha" data-sitekey="6Ld5jwMpAAAAANOjqcuof5dkxwIJ9lggJa74iV0c"></div> #}
+
          <button class="btn btn-custom px-3"type="submit">Send</button>
     </form>
 </div>

--- a/src/_includes/home.njk
+++ b/src/_includes/home.njk
@@ -125,7 +125,9 @@ layout: base.njk
               <input type="hidden" value="Please add me as a new subscriber">
               <button class="btn btn-custom px-3 mb-3"type="submit">Subscribe To Our Newsletter</button>
               
-              <input type="hidden" name="_next" value="{{ '/' | url}}">
+              {# email provider doesn't know what to do with the relative path #}
+              {# <input type="hidden" name="_next" value="{{ '/' | url}}"> #}
+              <input type="hidden" name="_next" value="https://actq.hubco.dev">
               <input type="hidden" name="_captcha" value="true">
               <p><small>By submitting this form you are registering to receive informative emails from Accounteque Services, Inc that will be sent to the email address entered above. At any time you can unsubscribe from these emails using the unsubscribe link included in each message, replying to any message with "unlist" in the subject line, or you can contact us directly at na@actq.com.</small></p>
             </form>


### PR DESCRIPTION
sending a message via the contact form or subscribing via email redirects the end user to formsubmit's website. As a result we need a hard coded/absolute path for the redirect.