### PR TITLE
Temp 2fa meta tag added to head

### DIFF
--- a/src/_includes/base.njk
+++ b/src/_includes/base.njk
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="cf-2fa-verify" value="KWpgNdt47ngR9Cl" />
     <title>{{ title }}</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />


### PR DESCRIPTION
This pull request introduces a small change to the `src/_includes/base.njk` file. A new meta tag has been added to include a `cf-2fa-verify` attribute for verification/password recovery.